### PR TITLE
Update set_hd_mode.sh to source from '.steamosrc' for user defined overrides

### DIFF
--- a/usr/bin/steamos/set_hd_mode.sh
+++ b/usr/bin/steamos/set_hd_mode.sh
@@ -30,6 +30,14 @@ function first_by_prefix_order() {
 GOODMODES=("3840x2160" "1920x1080" "1280x720")
 GOODRATES=("60.0" "59.9") # CEA modes guarantee or one the other, but not both?
 
+# Override the defaults from the user config
+if [ -f "$HOME/.steamosrc" ]; then
+    source "$HOME/.steamosrc"
+else
+    echo '#GOODMODES=("3840x2160" "1920x1080" "1280x720")' > "$HOME/.steamosrc"
+    echo '#GOODRATES=("60.0" "59.9")' >> "$HOME/.steamosrc"
+fi
+
 # First, some logging
 date
 xrandr --verbose


### PR DESCRIPTION
This addresses #2 and allows users to define variable overrides in `~/.steamosrc` to override the running resolution. It will also create a default `~/.steamosrc` with commented out options if one does not exist.