### PR TITLE
Hide `set_hd_mode.log` inside $HOME

### DIFF
--- a/usr/bin/steamos-session
+++ b/usr/bin/steamos-session
@@ -12,7 +12,7 @@ export MANGOHUD_CONFIG="no_display,toggle_hud=F3"
 # Add our bin directory with the set_hd_mode and dpkg-query replacement scripts
 export PATH=/usr/share/steamos-compositor-plus/bin:${PATH}
 
-set_hd_mode.sh >> $HOME/set_hd_mode.log
+set_hd_mode.sh >> $HOME/.set_hd_mode.log
 
 export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libmodeswitch_inhibitor.so:/usr/lib/i386-linux-gnu/libmodeswitch_inhibitor.so
 


### PR DESCRIPTION
As a minor annoyance described in #21 the best way to handle it is to make it a hidden file as `xsession-errors.log` and the like. We are not sure if any XDG directory structure is present on first startup and should not rely on it. By hiding it, we make sure it works and does not pollute user interaction with the filesystem.