### PR TITLE
Remove `MANGOHUD_CONFIG` environment variable that prevents using a `MangoHud.conf` file

### DIFF
--- a/usr/bin/steamos-session
+++ b/usr/bin/steamos-session
@@ -7,7 +7,6 @@ export HOMETEST_DESKTOP_USER=desktop
 export HOMETEST_DESKTOP_SESSION=gnome
 
 export MANGOHUD=1
-export MANGOHUD_CONFIG="no_display,toggle_hud=F3"
 
 # Add our bin directory with the set_hd_mode and dpkg-query replacement scripts
 export PATH=/usr/share/steamos-compositor-plus/bin:${PATH}


### PR DESCRIPTION
This should fix https://github.com/gamer-os/gamer-os/issues/206