### PR TITLE
replace gettimeofday with clock_gettime

### DIFF
--- a/src/steamcompmgr.c
+++ b/src/steamcompmgr.c
@@ -288,10 +288,9 @@ const int tfpAttribsRGBA[] = {
 static unsigned int
 get_time_in_milliseconds (void)
 {
-	struct timeval  tv;
-	
-	gettimeofday (&tv, NULL);
-	return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+	return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
 static void


### PR DESCRIPTION
Same rationale as the change in gamescope (https://github.com/Plagman/gamescope/pull/98) - more accurate and less expensive. 