### PR TITLE
Better logging

### DIFF
--- a/src/steamcompmgr.c
+++ b/src/steamcompmgr.c
@@ -888,14 +888,20 @@ paint_debug_info (Display *dpy)
 	
 	char messageBuffer[256];
 	
-	sprintf(messageBuffer, "Compositing at %.1f FPS", currentFrameRate);
+	sprintf(messageBuffer, "Compositing at %6.1f FPS", currentFrameRate);
 	
 	paint_message(messageBuffer, Y, 1.0f, 1.0f, 1.0f); Y += textYMax;
-	if (find_win(dpy, currentFocusWindow))
+	win *w = find_win(dpy, currentFocusWindow);
+	if (w)
 	{
 		if (gameFocused)
 		{
-			sprintf(messageBuffer, "Presenting game window %x", (unsigned int)currentFocusWindow);
+			if ( w->opacity < OPAQUE) {
+				sprintf(messageBuffer, "Compositing game window 0x%lx at opacity %.2f%%", (unsigned int)currentFocusWindow, (w->opacity / (float)OPAQUE) * 100);
+			} else {
+				sprintf(messageBuffer, "Presenting game window 0x%lx", (unsigned int)currentFocusWindow);
+			}
+			
 			paint_message(messageBuffer, Y, 0.0f, 1.0f, 0.0f); Y += textYMax;
 		}
 		else
@@ -910,13 +916,13 @@ paint_debug_info (Display *dpy)
 	
 	if (overlay && gamesRunningCount && overlay->opacity)
 	{
-		sprintf(messageBuffer, "Compositing overlay at opacity %f", overlay->opacity / (float)OPAQUE);
+		sprintf(messageBuffer, "Compositing overlay at opacity %.2f%%", (overlay->opacity / (float)OPAQUE) * 100);
 		paint_message(messageBuffer, Y, 1.0f, 0.0f, 1.0f); Y += textYMax;
 	}
 	
 	if (notification && gamesRunningCount && notification->opacity)
 	{
-		sprintf(messageBuffer, "Compositing notification at opacity %f", notification->opacity / (float)OPAQUE);
+		sprintf(messageBuffer, "Compositing notification at opacity %.2f%%", (notification->opacity / (float)OPAQUE) * 100);
 		paint_message(messageBuffer, Y, 1.0f, 0.0f, 1.0f); Y += textYMax;
 	}
 	
@@ -928,7 +934,6 @@ paint_debug_info (Display *dpy)
 		paint_message("Encountered X11 error", Y, 1.0f, 0.0f, 0.0f); Y += textYMax;
 	}
 
-	win *w = find_win(dpy, currentFocusWindow);
 	if (w && w->gameID) {
 		sprintf(messageBuffer, "Game ID: %u", w->gameID);
 		paint_message(messageBuffer, Y, 1.0f, 0.0f, 1.0f); Y += textYMax;
@@ -1270,7 +1275,7 @@ determine_and_apply_focus (Display *dpy)
 	{
 		set_win_hidden(dpy, find_win(dpy, currentFocusWindow), True);
 	}
-	
+
 	currentFocusWindow = focus->id;
 	w = focus;
 	
@@ -1803,11 +1808,11 @@ error (Display *dpy, XErrorEvent *ev)
 	}
 	o = ev->error_code - render_error;
 	switch (o) {
-		case BadPictFormat: name ="BadPictFormat"; break;
-		case BadPicture: name ="BadPicture"; break;
-		case BadPictOp: name ="BadPictOp"; break;
-		case BadGlyphSet: name ="BadGlyphSet"; break;
-		case BadGlyph: name ="BadGlyph"; break;
+		case BadPictFormat: name = "BadPictFormat"; break;
+		case BadPicture: name = "BadPicture"; break;
+		case BadPictOp: name = "BadPictOp"; break;
+		case BadGlyphSet: name = "BadGlyphSet"; break;
+		case BadGlyph: name = "BadGlyph"; break;
 		default: break;
 	}
 	

--- a/src/steamcompmgr.c
+++ b/src/steamcompmgr.c
@@ -1278,6 +1278,18 @@ determine_and_apply_focus (Display *dpy)
 		set_win_hidden(dpy, find_win(dpy, currentFocusWindow), True);
 	}
 
+	if ( debugEvents )
+	{
+		if ( currentFocusWindow != focus->id )
+		{
+			printf("determine_and_apply_focus: focus window was 0x%lx, is now 0x%lx\n", currentFocusWindow, focus->id );
+			char buf[512];
+			sprintf( buf,  "xwininfo -all -id 0x%lx; xprop -id 0x%lx; xwininfo -root -tree", focus->id, focus->id );
+			if ( system( buf ) != 0 )
+				fprintf (stderr, "Failed to get window info\n");
+		}
+	}
+	
 	currentFocusWindow = focus->id;
 	w = focus;
 	

--- a/src/steamcompmgr.c
+++ b/src/steamcompmgr.c
@@ -1025,6 +1025,7 @@ paint_all (Display *dpy)
 		w = find_win(dpy, currentFocusWindow);
 		ensure_win_resources(dpy, w);
 		// Just draw focused window as normal, be it Steam or the game
+		w->opacity = OPAQUE;
 		paint_window(dpy, w, False, False);
 		
 		if (focusedWindowNeedsScale)
@@ -1041,6 +1042,7 @@ paint_all (Display *dpy)
 				fadeOutWindowGone = False;
 			}
 			fadeOutWindow.id = None;
+			fadeOutWindow.opacity = TRANSLUCENT;
 			
 			// Finished fading out, mark previous window hidden
 			set_win_hidden(dpy, &fadeOutWindow, True);


### PR DESCRIPTION
This adds a lot more detail to the debug output (shows the symbolic names for the X events, what window they were for etc) and slightly changes the formatting on the debug overlay so that it also shows when windows are being faded and tries to pad the FPS so its a little more readable when its changing rapidly.  If xwininfo and/or xprop are installed it will show the full details of the window which just got focus followed by the list of all other windows.