### PR TITLE
Xrandr fix

### DIFF
--- a/usr/bin/steamos-session
+++ b/usr/bin/steamos-session
@@ -11,7 +11,7 @@ export MANGOHUD=1
 # Add our bin directory with the set_hd_mode and dpkg-query replacement scripts
 export PATH=/usr/share/steamos-compositor-plus/bin:${PATH}
 
-set_hd_mode.sh >> $HOME/.set_hd_mode.log
+set_hd_mode.sh >> $HOME/.set_hd_mode.log 2>&1
 
 export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libmodeswitch_inhibitor.so:/usr/lib/i386-linux-gnu/libmodeswitch_inhibitor.so
 

--- a/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
+++ b/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
@@ -102,7 +102,7 @@ for goodmode in "${GOODMODES[@]}"; do
 	fi
 
 	for goodrate in "${GOODRATES[@]}"; do
-		xrandr --output "$OUTPUT_NAME" --mode "$goodmode" --refresh "$goodrate" --rotation "$ROTATION"
+		xrandr --output "$OUTPUT_NAME" --mode "$goodmode" --refresh "$goodrate" --rotate "$ROTATION"
 		# If good return, we're done
 		if [[ $? -eq 0 ]]; then
 			exit 0


### PR DESCRIPTION
I have xrandr 1.5.1 (on Arch) and it doesn't accept `--rotation` as an argument, only `--rotate`.  Assumed that's a typo but if there are versions that take different arguments we might need to detect or try both here.