### PR TITLE
Add commented out command to enable stdout logging

### DIFF
--- a/usr/bin/steamos-session
+++ b/usr/bin/steamos-session
@@ -70,3 +70,4 @@ if command -v steam-tweaks > /dev/null; then
 fi
 
 $STEAMCMD
+#$STEAMCMD > /tmp/steam_stdout.log 2>&1


### PR DESCRIPTION
This PR adds a commented out command to enable Steam's `stdout` output logging that I couldn't figure out how to inspect in another way. That way, if a contributor such as me needs to inspect the `stdout` logs, they just need to comment/uncomment the last two lines of `/usr/bin/steamos-session`.

This is probably not the most appropriate way to tackle the issue, I am open to discuss it !