### PR TITLE
Suspend or Power Off via Power Button

### DIFF
--- a/etc/steamos-compositor-plus/sxhkdrc
+++ b/etc/steamos-compositor-plus/sxhkdrc
@@ -6,3 +6,6 @@ XF86MonBrightness{Up,Down}
 
 super + p
 	/usr/share/steamos-compositor-plus/bin/screen_toggle.sh
+
+XF86PowerOff
+	/usr/share/steamos-compositor-plus/bin/power_off.sh

--- a/usr/share/steamos-compositor-plus/bin/power_off.sh
+++ b/usr/share/steamos-compositor-plus/bin/power_off.sh
@@ -8,18 +8,19 @@ MAXSEC=2
 trap "rm -f $PIDFILE" EXIT
 
 if pidof -o %PPID -x $NAME >/dev/null; then
-        echo $PID > $PIDFILE
-	sleep $MAXSEC
-	exit 0
+    echo $PID > $PIDFILE
+    sleep $MAXSEC
+    exit 0
 fi
 
 while [ $SECONDS -lt $MAXSEC ]; do
-  if [ -f "$PIDFILE" ]; then 
-    OTHERPID=`cat $PIDFILE`
-    kill $OTHERPID
-    systemctl poweroff
-    exit 0
-  fi
+    if [ -f "$PIDFILE" ]; then 
+        OTHERPID=`cat $PIDFILE`
+        kill $OTHERPID
+        systemctl poweroff
+        exit 0
+    fi
 done
+
 systemctl suspend
 exit 0

--- a/usr/share/steamos-compositor-plus/bin/power_off.sh
+++ b/usr/share/steamos-compositor-plus/bin/power_off.sh
@@ -17,7 +17,7 @@ while [ $SECONDS -lt $MAXSEC ]; do
   if [ -f "$PIDFILE" ]; then 
     OTHERPID=`cat $PIDFILE`
     kill $OTHERPID
-    systemctl shutdown
+    systemctl poweroff
     exit 0
   fi
 done

--- a/usr/share/steamos-compositor-plus/bin/power_off.sh
+++ b/usr/share/steamos-compositor-plus/bin/power_off.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+NAME=$(basename $0)
+PID=$$
+PIDFILE=/tmp/$NAME.pid
+MAXSEC=2
+
+trap "rm -f $PIDFILE" EXIT
+
+if pidof -o %PPID -x $NAME >/dev/null; then
+        echo $PID > $PIDFILE
+	sleep $MAXSEC
+	exit 0
+fi
+
+while [ $SECONDS -lt $MAXSEC ]; do
+  if [ -f "$PIDFILE" ]; then 
+    OTHERPID=`cat $PIDFILE`
+    kill $OTHERPID
+    systemctl shutdown
+    exit 0
+  fi
+done
+systemctl suspend
+exit 0


### PR DESCRIPTION
Handles XF86PowerOff events through steamos-compositor. Single press enters suspend mode, double press enters poweroff mode. The current setting checks for multi press within 2 seconds. Behavior is enabled by setting HandlePowerKey=ignore in logind.conf. This is useful for handheld devices such as the Aya Neo, OneX Player, GPD Win3, and others.

Discussion should be had if this is the best approach in the script for handling these events as firmware on some devices might have different timers/behaviors. Alternative suggestions are requested.