### PR TITLE
Impoved Monitor Support

### DIFF
--- a/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
+++ b/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
@@ -66,7 +66,6 @@ CONFIG_PATH=${XDG_CONFIG_HOME:-$HOME/.config}
 CONFIG_FILE="$CONFIG_PATH/steamos-compositor-plus"
 
 # Override the defaults from the user config
-echo "Debug: USER: $USER"
 if [ -f "$CONFIG_FILE" ]; then
     source "$CONFIG_FILE"
 else
@@ -81,10 +80,10 @@ xrandr --verbose
 
 # List connected outputs
 ALL_OUTPUT_NAMES=$(xrandr | grep ' connected' | cut -f1 -d' ')
+
 # Default to first connected output
 OUTPUT_NAME=$(echo $ALL_OUTPUT_NAMES | cut -f1 -d' ')
-echo "Debug: ALL_OUTPUT_NAMES: $ALL_OUTPUT_NAMES"
-echo "Debug: OUTPUT_NAME: $OUTPUT_NAME"
+
 # If any is connected, give priority to HDMI then DP
 OUTPUT_PRIORITY="HDMI DisplayPort DP LVDS"
 PREFERRED_OUTPUT=$(first_by_prefix_order ALL_OUTPUT_NAMES[@] OUTPUT_PRIORITY[@])
@@ -100,10 +99,7 @@ for i in $ALL_OUTPUT_NAMES; do
 	fi
 done
 
-
 CURRENT_MODELINE=`xrandr | grep \* | tr -s ' ' | head -n1`
-printf "Debug: CURRENT_MODELINE: $CURRENT_MODELINE \nxrandr | grep \* | tr -s ' ' | head -n1"
-
 CURRENT_MODE=`echo "$CURRENT_MODELINE" | cut -d' ' -f2`
 CURRENT_RATE=`echo "$CURRENT_MODELINE" | tr ' ' '\n' | grep \* | tr -d \* | tr -d +`
 
@@ -116,7 +112,7 @@ fi
 
 w=`echo $CURRENT_MODE | cut -dx -f1`
 h=`echo $CURRENT_MODE | cut -dx -f2`
-echo "Debug: CURRENT_MODE: $CURRENT_MODE, WxH: $w $h"
+
 if [ "$h" -gt "$w" ]; then
 	TRANSPOSED=true
 fi

--- a/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
+++ b/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
@@ -84,7 +84,7 @@ ALL_OUTPUT_NAMES=$(xrandr | grep ' connected' | cut -f1 -d' ')
 OUTPUT_NAME=$(echo $ALL_OUTPUT_NAMES | cut -f1 -d' ')
 
 # If any is connected, give priority to HDMI then DP
-OUTPUT_PRIORITY="HDMI DP"
+OUTPUT_PRIORITY="HDMI DisplayPort DP"
 PREFERRED_OUTPUT=$(first_by_prefix_order ALL_OUTPUT_NAMES[@] OUTPUT_PRIORITY[@])
 if [[ -n "$PREFERRED_OUTPUT" ]] ; then
     OUTPUT_NAME=$PREFERRED_OUTPUT

--- a/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
+++ b/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
@@ -112,6 +112,7 @@ fi
 
 w=`echo $CURRENT_MODE | cut -dx -f1`
 h=`echo $CURRENT_MODE | cut -dx -f2`
+
 if [ "$h" -gt "$w" ]; then
 	TRANSPOSED=true
 fi
@@ -126,12 +127,13 @@ fi
 
 # detect and rotate touch screen
 TOUCHSCREEN=$(udevadm info --export-db | sed 's/^$/;;/' | tr '\n' '%%' | tr ';;' '\n' | grep ID_INPUT_TOUCHSCREEN=1 | tr '%%' '\n' | grep "E: NAME=" | head -1 | cut -d\" -f 2)
-TOUCHSCREEN_DISPLAYS=["eDP LVDS"]
-TOUCHSCREEN_OUTPUT=$(first_by_prefix_order OUTPUT_NAME TOUCHSCREEN_DISPLAYS[@])
-echo "Touchscreen: $TOUCHSCREEN, Display: $TOUCHSCREEN_OUTPUT"
-if [ -n "$TOUCHSCREEN" ] && [ -n "$TOUCHSCREEN_OUTPUT" ]; then
+TOUCHSCREEN_DISPLAYS=("eDP" "LVDS")
+TOUCH_IDS=$(xinput --list | egrep -o "$TOUCHSCREEN.+id=[0-9]+" | egrep -o "[0-9]+")
+if [ -n "$TOUCHSCREEN" ] && [[ "${TOUCHSCREEN_DISPLAYS[*]}" =~ $OUTPUT_NAME ]]; then
+	for ID in $TOUCH_IDS; do
+		xinput enable $ID
+	done
 	MATRIX="1 0 0 0 1 0 0 0 1"
-	echo "Calibrating touchscreen"
 	if [ "$ROTATION" = "right" ]; then
 		MATRIX="0 1 0 -1 0 1 0 0 1"
 	elif [ "$ROTATION" = "left" ]; then
@@ -145,9 +147,7 @@ if [ -n "$TOUCHSCREEN" ] && [ -n "$TOUCHSCREEN_OUTPUT" ]; then
 	xinput set-prop "pointer:$TOUCHSCREEN" --type=float "Coordinate Transformation Matrix" $MATRIX
 
 # disable touch screen if using external display
-elif [ -n "$TOUCHSCREEN" ] && [ -z "$TOUCHSCREEN_OUTPUT" ]; then
-	echo "Disabling touchscreen"
-	TOUCH_IDS=$(xinput --list | egrep -o "$TOUCHSCREEN.+id=[0-9]+" | egrep -o "[0-9]+")
+elif [ -n "$TOUCHSCREEN" ] && [[ ! "${TOUCHSCREEN_DISPLAYS[*]}" =~ $OUTPUT_NAME ]]; then
 	for ID in $TOUCH_IDS; do
 		xinput disable $ID
 	done

--- a/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
+++ b/usr/share/steamos-compositor-plus/bin/set_hd_mode.sh
@@ -66,6 +66,7 @@ CONFIG_PATH=${XDG_CONFIG_HOME:-$HOME/.config}
 CONFIG_FILE="$CONFIG_PATH/steamos-compositor-plus"
 
 # Override the defaults from the user config
+echo "Debug: USER: $USER"
 if [ -f "$CONFIG_FILE" ]; then
     source "$CONFIG_FILE"
 else
@@ -82,14 +83,16 @@ xrandr --verbose
 ALL_OUTPUT_NAMES=$(xrandr | grep ' connected' | cut -f1 -d' ')
 # Default to first connected output
 OUTPUT_NAME=$(echo $ALL_OUTPUT_NAMES | cut -f1 -d' ')
-
+echo "Debug: ALL_OUTPUT_NAMES: $ALL_OUTPUT_NAMES"
+echo "Debug: OUTPUT_NAME: $OUTPUT_NAME"
 # If any is connected, give priority to HDMI then DP
 OUTPUT_PRIORITY="HDMI DisplayPort DP LVDS"
 PREFERRED_OUTPUT=$(first_by_prefix_order ALL_OUTPUT_NAMES[@] OUTPUT_PRIORITY[@])
 if [[ -n "$PREFERRED_OUTPUT" ]] ; then
     OUTPUT_NAME=$PREFERRED_OUTPUT
 fi
-
+# Set an initial value to test against
+xrandr --output $OUTPUT_NAME --auto
 # Disable everything but the selected output
 for i in $ALL_OUTPUT_NAMES; do
 	if [ "$i" != "$OUTPUT_NAME" ]; then
@@ -99,6 +102,7 @@ done
 
 
 CURRENT_MODELINE=`xrandr | grep \* | tr -s ' ' | head -n1`
+printf "Debug: CURRENT_MODELINE: $CURRENT_MODELINE \nxrandr | grep \* | tr -s ' ' | head -n1"
 
 CURRENT_MODE=`echo "$CURRENT_MODELINE" | cut -d' ' -f2`
 CURRENT_RATE=`echo "$CURRENT_MODELINE" | tr ' ' '\n' | grep \* | tr -d \* | tr -d +`
@@ -112,7 +116,7 @@ fi
 
 w=`echo $CURRENT_MODE | cut -dx -f1`
 h=`echo $CURRENT_MODE | cut -dx -f2`
-
+echo "Debug: CURRENT_MODE: $CURRENT_MODE, WxH: $w $h"
 if [ "$h" -gt "$w" ]; then
 	TRANSPOSED=true
 fi


### PR DESCRIPTION
- Enables handhelds (such as Aya Neo) using native resolution of a docked display if steamcompmgr is restarted or system is rebooted. 
- Assumes touch devices are part of an internal display and only enables them if internal display in used (eDP/LVDS).